### PR TITLE
add expires_at

### DIFF
--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -25,7 +25,7 @@ module XeroGateway
     extend Forwardable
     def_delegators :access_token, :get, :post, :put, :delete
 
-    attr_reader   :ctoken, :csecret, :consumer_options, :authorization_expires_at
+    attr_reader   :ctoken, :csecret, :consumer_options, :authorization_expires_at, :expires_at
     attr_accessor :session_handle
 
     def initialize(ctoken, csecret, options = {})


### PR DESCRIPTION
specified as a delegated method in XeroGateway::Gateway, but not exposed so usage causes exception.