### PR TITLE
add expires_at

### DIFF
--- a/lib/xero_gateway/oauth.rb
+++ b/lib/xero_gateway/oauth.rb
@@ -22,7 +22,7 @@ module XeroGateway
       }.freeze
     end
 
-    attr_reader   :ctoken, :csecret, :consumer_options, :authorization_expires_at
+    attr_reader   :ctoken, :csecret, :consumer_options, :authorization_expires_at, :expires_at
     attr_accessor :session_handle
 
     def initialize(ctoken, csecret, options = {})


### PR DESCRIPTION
XeroGateway::OAuth#expires_at is specified as a method delegated to in XeroGateway::Gateway here, but the method doesn't exist (so, usage results in exception). An instance variable is already being set for it; this just makes it available.

this is same change for add-expires-at, but that's involved in a PR against upstream repo, so don't want to alter to let merge in with our master.